### PR TITLE
Options: Initialize elementa{Dev,Debug} from VM options

### DIFF
--- a/src/main/kotlin/gg/essential/elementa/utils/options.kt
+++ b/src/main/kotlin/gg/essential/elementa/utils/options.kt
@@ -1,18 +1,18 @@
 package gg.essential.elementa.utils
 
-var elementaDev: Boolean = false
+internal val devPropSet = System.getProperty("elementa.dev")?.toBoolean() ?: false
+private val debugPropSet = System.getProperty("elementa.debug")?.toBoolean() ?: false
+
+var elementaDev: Boolean = devPropSet
     set(value) {
         if (devPropSet) {
             field = value
         }
     }
 
-var elementaDebug: Boolean = false
+var elementaDebug: Boolean = debugPropSet
     set(value) {
         if (debugPropSet) {
             field = value
         }
     }
-
-internal val devPropSet = System.getProperty("elementa.dev")?.toBoolean() ?: false
-private val debugPropSet = System.getProperty("elementa.debug")?.toBoolean() ?: false


### PR DESCRIPTION
Previously, these would always just be false (as they weren't set anywhere). Not totally sure what the point of having these fields configured like this is, but at least they work now. 