### PR TITLE
ConstraintResolutionGui: Display the component class and name

### DIFF
--- a/src/main/kotlin/gg/essential/elementa/constraints/resolution/ConstraintResolutionGui.kt
+++ b/src/main/kotlin/gg/essential/elementa/constraints/resolution/ConstraintResolutionGui.kt
@@ -263,7 +263,10 @@ class ConstraintResolutionGui(
             right childOf this
 
             if (index != nodes!!.lastIndex) {
-                UIText("§7Component: §r${node.component.componentName}@${Integer.toHexString(node.component.hashCode())}").constrain {
+                val componentClassName = node.component.javaClass.simpleName.ifEmpty { "UnknownType" }
+                val componentDisplayName = node.component.componentName.let { if (it == componentClassName) it else "$componentClassName: $it" }
+
+                UIText("§7Component: §r$componentDisplayName").constrain {
                     y = SiblingConstraint()
                 } childOf right
 


### PR DESCRIPTION
This is the way the Inspector does it, and I think it's much better.
The hex code was to uniquely identifier the component in the list view,
but if the user is having trouble determining the components from the
list view, they should either look at the tree view or use delegation
to set the component names.