### PR TITLE
MarkdownComponent: Improve ParagraphDrawable error message

### DIFF
--- a/src/main/kotlin/gg/essential/elementa/markdown/drawables/ParagraphDrawable.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/drawables/ParagraphDrawable.kt
@@ -197,8 +197,9 @@ class ParagraphDrawable(
                         // boundary. In this case we opt to split again, breaking
                         // words if we have to. We run split twice here, but as
                         // this is a rare edge case, it's not a problem.
-                        val splitResult3 = target.split(width, breakWords = true)
-                            ?: throw IllegalStateException("not possible")
+                        val splitResult3 = target.split(width, breakWords = true) ?: throw IllegalStateException(
+                            "MarkdownComponent's width (${md.getWidth()}) is too small to render its content"
+                        )
 
                         layout(splitResult3.first, splitResult3.first.width())
                         gotoNextLine()


### PR DESCRIPTION
This is very much possible if the component's width is tiny (i.e. 0), so the error message should be more helpful. 