### PR TITLE
MarkdownComponent: Fix a couple bugs

### DIFF
--- a/src/main/kotlin/gg/essential/elementa/markdown/MarkdownComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/MarkdownComponent.kt
@@ -118,15 +118,6 @@ class MarkdownComponent @JvmOverloads constructor(
      * @see Drawable.layout
      */
     fun layout() {
-        // TODO: ParagraphDrawable currently directly mutates its drawables, splitting them as necessary. This will
-        //       however cause text to actually be layed out differently if layout is called more than once, cause
-        //       the answer to "does this drawable fit into the current line" changes.
-        //       Such behavior causes inconsistent layout result and makes it difficult to reason about bugs in code
-        //       which changes behavior upon re-layout, so for now we'll completely re-parse on re-layout so we always
-        //       start from the same drawables and get the same result.
-        //       For performance reasons, this should be removed once it no longer mutate the drawables list.
-        reparse()
-
         baseX = getLeft()
         baseY = getTop()
         var currY = baseY

--- a/src/main/kotlin/gg/essential/elementa/markdown/drawables/ParagraphDrawable.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/drawables/ParagraphDrawable.kt
@@ -99,8 +99,8 @@ class ParagraphDrawable(
         }
 
         for ((index, text) in originalDrawables.withIndex()) {
-            if (text is SoftBreakDrawable) {
-                if (config.paragraphConfig.softBreakIsNewline) {
+            if (text is SoftBreakDrawable || text is HardBreakDrawable) {
+                if (config.paragraphConfig.softBreakIsNewline || text is HardBreakDrawable) {
                     gotoNextLine()
                 } else {
                     val previousStyle = (newDrawables.lastOrNull { it is TextDrawable } as? TextDrawable)?.let {
@@ -131,10 +131,6 @@ class ParagraphDrawable(
                     trimNextText = true
                 }
                 continue
-            }
-
-            if (text is HardBreakDrawable) {
-                TODO("I don't think this should ever happen, but I'm not 100% sure")
             }
 
             if (text is ImageDrawable) {

--- a/src/main/kotlin/gg/essential/elementa/markdown/drawables/ParagraphDrawable.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/drawables/ParagraphDrawable.kt
@@ -103,8 +103,9 @@ class ParagraphDrawable(
                 if (config.paragraphConfig.softBreakIsNewline) {
                     gotoNextLine()
                 } else {
-                    val previousStyle = (newDrawables.lastOrNull { it is TextDrawable } as? TextDrawable)?.style
-                        ?: TextDrawable.Style.EMPTY
+                    val previousStyle = (newDrawables.lastOrNull { it is TextDrawable } as? TextDrawable)?.let {
+                        it.style.copy(isCode = false)
+                    } ?: TextDrawable.Style.EMPTY
                     val newText = TextDrawable(md, " ", previousStyle)
 
                     // Do this before laying out newText, so that newText isn't in the


### PR DESCRIPTION
- Fix inline images _always_ crashing
- Fix `SoftBreakDrawable` after a code-styled text causing a weird empty code-styled drawable to appear
- Fix `HardBreakDrawable` causing a crash when present in a `ParagraphDrawable`