### PR TITLE
Use extended generics rather than UIComponent

### DIFF
--- a/src/main/kotlin/gg/essential/elementa/dsl/animations.kt
+++ b/src/main/kotlin/gg/essential/elementa/dsl/animations.kt
@@ -7,7 +7,7 @@ import gg.essential.elementa.constraints.animation.AnimatingConstraints
  * Wrapper around [UIComponent.makeAnimation] and [UIComponent.animateTo],
  * providing a handy dandy DSL.
  */
-inline fun UIComponent.animate(animation: AnimatingConstraints.() -> Unit) = apply {
+inline fun <T : UIComponent> T.animate(animation: AnimatingConstraints.() -> Unit) = apply {
     val anim = this.makeAnimation()
     anim.animation()
     this.animateTo(anim)


### PR DESCRIPTION
To allow for better chaining, as normally it will cast itself to a UIComponent, which is problematic when assigning to any other type of component.