### PR TITLE
MarkdownComponent: Layout in animationFrame instead of draw

### DIFF
--- a/src/main/kotlin/gg/essential/elementa/markdown/MarkdownComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/MarkdownComponent.kt
@@ -134,7 +134,9 @@ class MarkdownComponent @JvmOverloads constructor(
         setHeight((currY - baseY).coerceAtMost(maxHeight.getHeight(this)).pixels())
     }
 
-    override fun draw(matrixStack: UMatrixStack) {
+    override fun animationFrame() {
+        super.animationFrame()
+
         if (!initialLayout) {
             initialLayout = true
             reparse()
@@ -147,7 +149,9 @@ class MarkdownComponent @JvmOverloads constructor(
         if (currentValues != lastValues)
             layout()
         lastValues = currentValues
+    }
 
+    override fun draw(matrixStack: UMatrixStack) {
         beforeDrawCompat(matrixStack)
 
         val drawState = DrawState(getLeft() - baseX, getTop() - baseY)

--- a/src/main/kotlin/gg/essential/elementa/markdown/MarkdownComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/MarkdownComponent.kt
@@ -45,7 +45,7 @@ class MarkdownComponent @JvmOverloads constructor(
     private var cursor: Cursor<*>? = null
     private var selection: Selection? = null
     private var canDrag = false
-    private var initialLayout = false
+    private var needsInitialLayout = true
 
     init {
         if (!disableSelection) {
@@ -137,8 +137,8 @@ class MarkdownComponent @JvmOverloads constructor(
     override fun animationFrame() {
         super.animationFrame()
 
-        if (!initialLayout) {
-            initialLayout = true
+        if (needsInitialLayout) {
+            needsInitialLayout = false
             reparse()
             layout()
             lastValues = constraintValues()

--- a/src/main/kotlin/gg/essential/elementa/markdown/MarkdownComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/MarkdownComponent.kt
@@ -152,7 +152,7 @@ class MarkdownComponent @JvmOverloads constructor(
     }
 
     override fun draw(matrixStack: UMatrixStack) {
-        beforeDrawCompat(matrixStack)
+        beforeDraw(matrixStack)
 
         val drawState = DrawState(getLeft() - baseX, getTop() - baseY)
 


### PR DESCRIPTION
> Cause that's the place where layout is supposed to take place. One reason for
why this is the better place is that `draw` isn't called until the component is
drawn, and elementa doesn't draw components if they're not visible, therefore
markdown components where pretty much unusable with scrollbars cause their size
would be all wrong.

Sort of by necessity, this also fixes a bunch more things in MarkdownComponent:
>  MarkdownComponent: Stop abusing afterInitialization method
>
> There's no need for MarkdownComponent to override it, and then having to
manually call it because it can't call super.draw because that's too later for
when it wishes to draw.
>
> Also happens to fix effect initialization (which happened in the original
afterInitialization), the effect before draw callback (which was forgotten
about), incorrect timing of the effect before children draw callback (which was
called before the component is draw) and anything which requires `super.draw` to
function correctly (e.g. debug outlines).