### PR TITLE
MarkdownComponent: Fix ABI backwards compatibility

### DIFF
--- a/src/main/kotlin/gg/essential/elementa/markdown/MarkdownComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/MarkdownComponent.kt
@@ -23,13 +23,22 @@ import gg.essential.universal.UMatrixStack
  * done with direct render calls instead of through the component
  * hierarchy.
  */
-class MarkdownComponent @JvmOverloads constructor(
+class MarkdownComponent(
     text: String,
     val config: MarkdownConfig = MarkdownConfig(),
     private val codeFontPointSize: Float = 10f,
     private val codeFontRenderer: FontProvider = ElementaFonts.JETBRAINS_MONO,
     private val disableSelection: Boolean = false,
 ) : UIComponent() {
+
+    @JvmOverloads
+    constructor(
+        text: String,
+        config: MarkdownConfig = MarkdownConfig(),
+        codeFontPointSize: Float = 10f,
+        codeFontRenderer: FontProvider = ElementaFonts.JETBRAINS_MONO,
+    ) : this(text, config, codeFontPointSize, codeFontRenderer, false)
+
     private var textState: State<String> = BasicState(text)
     private var removeListener = textState.onSetValue {
         reparse()


### PR DESCRIPTION
An optional argument was added to the constructor in 9ea0135, which removes the
old synthetic Kotlin defaults constructor. To preserve binary compatibility, we
need to keep the original constructor overload with the exact same optional
arguments as it always used to have.