### PR TITLE
Inspector: Fix debug not being re-set when inspector is closed

### DIFF
--- a/src/main/kotlin/gg/essential/elementa/components/inspector/Inspector.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/inspector/Inspector.kt
@@ -244,8 +244,6 @@ class Inspector @JvmOverloads constructor(
     }
 
     override fun draw(matrixStack: UMatrixStack) {
-        val debugState = elementaDebug
-        elementaDebug = false
         // If we got removed from our parent, we need to un-float ourselves
         if (!isMounted()) {
             Window.enqueueRenderOperation { setFloating(false) }
@@ -291,8 +289,13 @@ class Inspector @JvmOverloads constructor(
             UGraphics.disableDepth()
         }
 
-        super.draw(matrixStack)
-        elementaDebug = debugState
+        val debugState = elementaDebug
+        elementaDebug = false
+        try {
+            super.draw(matrixStack)
+        } finally {
+            elementaDebug = debugState
+        }
     }
 
     companion object {


### PR DESCRIPTION
Because we return if the component is no longer mounted. So elementaDebug gets
disabled but not re-set again.
To fix that, we only overwrite elementaDebug for the duration of the
`super.draw` call (that's the only thing which matters) and then re-set it in a
finally block.