### PR TITLE
Markdown: fix images not moving text after it down appropriately

### DIFF
--- a/src/main/kotlin/gg/essential/elementa/markdown/drawables/ParagraphDrawable.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/drawables/ParagraphDrawable.kt
@@ -234,13 +234,10 @@ class ParagraphDrawable(
 
         // We can have extra drawables in the current line that didn't get handled
         // by the last iteration of the loop
-        if (currentLine.isNotEmpty()) {
-            lines.add(currentLine.toList())
-            currY += maxLineHeight
-        } else {
-            // There isn't a next line, so this space shouldn't be there
-            currY -= config.paragraphConfig.spaceBetweenLines
-        }
+        if (currentLine.isNotEmpty()) gotoNextLine()
+
+        // There isn't a next line, so this space shouldn't be there
+        if (lines.isNotEmpty()) currY -= config.paragraphConfig.spaceBetweenLines
 
         if (centered) {
             // Offset each text component by half of the space at the end of each line

--- a/src/main/kotlin/gg/essential/elementa/markdown/drawables/ParagraphDrawable.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/drawables/ParagraphDrawable.kt
@@ -80,13 +80,9 @@ class ParagraphDrawable(
         val currentLine = mutableListOf<Drawable>()
         var maxLineHeight = Float.MIN_VALUE
 
-        var prevY = y
-
         fun gotoNextLine() {
-            prevY = currY
-
             currX = x
-            currY += maxLineHeight * scaleModifier + config.paragraphConfig.spaceBetweenLines
+            currY += maxLineHeight + config.paragraphConfig.spaceBetweenLines
 
             if (maxLineHeight > 9f) {
                 for (drawable in currentLine)
@@ -112,9 +108,9 @@ class ParagraphDrawable(
             drawable.layout(currX, currY, newWidth).also {
                 if (it.height > maxLineHeight)
                     maxLineHeight = it.height
+                widthRemaining -= it.width
+                currX += it.width
             }
-            widthRemaining -= newWidth
-            currX += newWidth
             trimNextText = false
             currentLine.add(drawable)
             newDrawables.add(drawable)
@@ -156,7 +152,7 @@ class ParagraphDrawable(
             }
 
             if (text is ImageDrawable) {
-                gotoNextLine()
+                if (currentLine.isNotEmpty()) gotoNextLine()
                 layout(text, width)
                 gotoNextLine()
                 continue
@@ -238,8 +234,13 @@ class ParagraphDrawable(
 
         // We can have extra drawables in the current line that didn't get handled
         // by the last iteration of the loop
-        if (currentLine.isNotEmpty())
+        if (currentLine.isNotEmpty()) {
             lines.add(currentLine.toList())
+            currY += maxLineHeight
+        } else {
+            // There isn't a next line, so this space shouldn't be there
+            currY -= config.paragraphConfig.spaceBetweenLines
+        }
 
         if (centered) {
             // Offset each text component by half of the space at the end of each line
@@ -265,8 +266,7 @@ class ParagraphDrawable(
 
         drawables.setDrawables(newDrawables)
 
-        val height = (if (currentLine.isNotEmpty()) currY else prevY) - y + 9f * scaleModifier +
-                if (insertSpaceAfter) config.paragraphConfig.spaceAfter else 0f
+        val height = currY - y + if (insertSpaceAfter) config.paragraphConfig.spaceAfter else 0f
 
         return Layout(
             x,
@@ -387,7 +387,8 @@ class ParagraphDrawable(
 
         // Step 5: Get the string offset position in the current text
 
-        fun textWidth(offset: Int) = currentDrawable.formattedText.substring(0, offset).width(currentDrawable.scaleModifier)
+        fun textWidth(offset: Int) =
+            currentDrawable.formattedText.substring(0, offset).width(currentDrawable.scaleModifier)
 
         var offset = currentDrawable.style.numFormattingChars
         var cachedWidth = 0f


### PR DESCRIPTION
- Remove `scaleModifier` from `currY` calculation because components who use it already pass it their height to maxLineHeight with it applied (see `ParagraphDrawable` line 110 and `TextDrawable` line 126)
- Remove prevY since it makes the paragraph report a size one line smaller then it should be
- Use with drawable reports for `widthRemaining` and `currX` so it is accurate for everything and not only text
- Add size of last line properly or if there is none remove the extra space

Code used for example:
```kt
        MarkdownComponent(
            "![](https://picsum.photos/800/300)" +
                    "\n# Markdown Test"
        ).constrain {
            x = CenterConstraint()
            y = 0.pixels()
            width = 800.pixels()
            height = 100.percent()
        } childOf window
```
Before:
![image](https://user-images.githubusercontent.com/67508414/235887678-c4895ee2-0c23-40b5-8eec-2f17289148c3.png)
After: 
![image](https://user-images.githubusercontent.com/67508414/235888272-10888dbe-f012-4541-84b7-34229aee3e6d.png)