### PR TITLE
Markdown: make images able to draw side by side with other images or text

### DIFF
--- a/src/main/kotlin/gg/essential/elementa/markdown/drawables/ImageDrawable.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/drawables/ImageDrawable.kt
@@ -83,6 +83,8 @@ class ImageDrawable(md: MarkdownComponent, val url: URL, private val fallback: D
     // TODO: Rename this function?
     override fun hasSelectedText() = selected
 
+    fun getImageWidth(): Float = image.imageWidth
+
     private inner class ShiftableMDPixelConstraint(val base: Float, var shift: Float) : XConstraint, YConstraint {
         override var cachedValue = 0f
         override var recalculate = true

--- a/src/main/kotlin/gg/essential/elementa/markdown/drawables/ParagraphDrawable.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/drawables/ParagraphDrawable.kt
@@ -152,9 +152,8 @@ class ParagraphDrawable(
             }
 
             if (text is ImageDrawable) {
-                if (currentLine.isNotEmpty()) gotoNextLine()
+                if (widthRemaining - text.getImageWidth() <= 0) gotoNextLine()
                 layout(text, width)
-                gotoNextLine()
                 continue
             }
 

--- a/src/main/kotlin/gg/essential/elementa/markdown/drawables/ParagraphDrawable.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/drawables/ParagraphDrawable.kt
@@ -80,13 +80,9 @@ class ParagraphDrawable(
         val currentLine = mutableListOf<Drawable>()
         var maxLineHeight = Float.MIN_VALUE
 
-        var prevY = y
-
         fun gotoNextLine() {
-            prevY = currY
-
             currX = x
-            currY += maxLineHeight * scaleModifier + config.paragraphConfig.spaceBetweenLines
+            currY += maxLineHeight + config.paragraphConfig.spaceBetweenLines
 
             if (maxLineHeight > 9f) {
                 for (drawable in currentLine)
@@ -112,9 +108,9 @@ class ParagraphDrawable(
             drawable.layout(currX, currY, newWidth).also {
                 if (it.height > maxLineHeight)
                     maxLineHeight = it.height
+                widthRemaining -= it.width
+                currX += it.width
             }
-            widthRemaining -= newWidth
-            currX += newWidth
             trimNextText = false
             currentLine.add(drawable)
             newDrawables.add(drawable)
@@ -156,7 +152,7 @@ class ParagraphDrawable(
             }
 
             if (text is ImageDrawable) {
-                gotoNextLine()
+                if (currentLine.isNotEmpty()) gotoNextLine()
                 layout(text, width)
                 gotoNextLine()
                 continue
@@ -238,8 +234,13 @@ class ParagraphDrawable(
 
         // We can have extra drawables in the current line that didn't get handled
         // by the last iteration of the loop
-        if (currentLine.isNotEmpty())
+        if (currentLine.isNotEmpty()) {
             lines.add(currentLine.toList())
+            currY += maxLineHeight
+        } else {
+            // There isn't a next line, so this space shouldn't be there
+            currY -= config.paragraphConfig.spaceBetweenLines
+        }
 
         if (centered) {
             // Offset each text component by half of the space at the end of each line
@@ -265,8 +266,7 @@ class ParagraphDrawable(
 
         drawables.setDrawables(newDrawables)
 
-        val height = (if (currentLine.isNotEmpty()) currY else prevY) - y + 9f * scaleModifier +
-                if (insertSpaceAfter) config.paragraphConfig.spaceAfter else 0f
+        val height = currY - y + if (insertSpaceAfter) config.paragraphConfig.spaceAfter else 0f
 
         return Layout(
             x,
@@ -387,7 +387,8 @@ class ParagraphDrawable(
 
         // Step 5: Get the string offset position in the current text
 
-        fun textWidth(offset: Int) = currentDrawable.formattedText.substring(0, offset).width(currentDrawable.scaleModifier)
+        fun textWidth(offset: Int) =
+            currentDrawable.formattedText.substring(0, offset).width(currentDrawable.scaleModifier)
 
         var offset = currentDrawable.style.numFormattingChars
         var cachedWidth = 0f


### PR DESCRIPTION
This pull request is based on #111 to prevent any possible merge conflicts with it

This pull request makes it so images can render side by side other images or text.
Code used for example:
```kt
        MarkdownComponent(
            "![](https://picsum.photos/225)![](https://picsum.photos/225)![](https://picsum.photos/225) Small images with text that wraps directly after it."
        ).constrain {
            x = CenterConstraint()
            y = 0.pixels()
            width = 800.pixels()
            height = 100.percent()
        } childOf window
```
Before: 
![image](https://user-images.githubusercontent.com/67508414/235888822-8c6c09ab-14d1-4492-9853-eb9944119251.png)
After: 
![image](https://user-images.githubusercontent.com/67508414/235888992-a6e13a14-8986-4d3c-93c6-c585c2331c83.png)


While I couldn't find the spec detailing that this is the way to do it, I believe it is since GitHub (and every other markdown renderer I know of) does it.
Example:
```md
![](picsum.photos/200/100)![](picsum.photos/200/100)text
```
renders as:
![](https://picsum.photos/200/100)![](https://picsum.photos/200/100)text