### PR TITLE
Markdown: allow the use of an ImageCache with MarkdownComponent

### DIFF
--- a/api/Elementa.api
+++ b/api/Elementa.api
@@ -3152,14 +3152,16 @@ public final class gg/essential/elementa/markdown/MarkdownComponent : gg/essenti
 	public fun <init> (Ljava/lang/String;Lgg/essential/elementa/markdown/MarkdownConfig;)V
 	public fun <init> (Ljava/lang/String;Lgg/essential/elementa/markdown/MarkdownConfig;F)V
 	public fun <init> (Ljava/lang/String;Lgg/essential/elementa/markdown/MarkdownConfig;FLgg/essential/elementa/font/FontProvider;)V
-	public synthetic fun <init> (Ljava/lang/String;Lgg/essential/elementa/markdown/MarkdownConfig;FLgg/essential/elementa/font/FontProvider;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/lang/String;Lgg/essential/elementa/markdown/MarkdownConfig;FLgg/essential/elementa/font/FontProvider;Z)V
 	public synthetic fun <init> (Ljava/lang/String;Lgg/essential/elementa/markdown/MarkdownConfig;FLgg/essential/elementa/font/FontProvider;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lgg/essential/elementa/markdown/MarkdownConfig;FLgg/essential/elementa/font/FontProvider;ZLgg/essential/elementa/components/image/ImageCache;)V
+	public synthetic fun <init> (Ljava/lang/String;Lgg/essential/elementa/markdown/MarkdownConfig;FLgg/essential/elementa/font/FontProvider;ZLgg/essential/elementa/components/image/ImageCache;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun animationFrame ()V
 	public final fun bindText (Lgg/essential/elementa/state/State;)Lgg/essential/elementa/markdown/MarkdownComponent;
 	public fun draw (Lgg/essential/universal/UMatrixStack;)V
 	public final fun getConfig ()Lgg/essential/elementa/markdown/MarkdownConfig;
 	public final fun getDrawables ()Lgg/essential/elementa/markdown/drawables/DrawableList;
+	public final fun getImageCache ()Lgg/essential/elementa/components/image/ImageCache;
 	public final fun getMaxTextLineWidth ()F
 	public final fun getSectionOffsets ()Ljava/util/Map;
 	public final fun layout ()V

--- a/api/Elementa.api
+++ b/api/Elementa.api
@@ -3152,6 +3152,7 @@ public final class gg/essential/elementa/markdown/MarkdownComponent : gg/essenti
 	public fun <init> (Ljava/lang/String;Lgg/essential/elementa/markdown/MarkdownConfig;)V
 	public fun <init> (Ljava/lang/String;Lgg/essential/elementa/markdown/MarkdownConfig;F)V
 	public fun <init> (Ljava/lang/String;Lgg/essential/elementa/markdown/MarkdownConfig;FLgg/essential/elementa/font/FontProvider;)V
+	public synthetic fun <init> (Ljava/lang/String;Lgg/essential/elementa/markdown/MarkdownConfig;FLgg/essential/elementa/font/FontProvider;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/lang/String;Lgg/essential/elementa/markdown/MarkdownConfig;FLgg/essential/elementa/font/FontProvider;Z)V
 	public synthetic fun <init> (Ljava/lang/String;Lgg/essential/elementa/markdown/MarkdownConfig;FLgg/essential/elementa/font/FontProvider;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/lang/String;Lgg/essential/elementa/markdown/MarkdownConfig;FLgg/essential/elementa/font/FontProvider;ZLgg/essential/elementa/components/image/ImageCache;)V

--- a/src/main/kotlin/gg/essential/elementa/markdown/MarkdownComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/MarkdownComponent.kt
@@ -5,6 +5,7 @@ import gg.essential.elementa.components.MarkdownNode
 import gg.essential.elementa.components.TreeListComponent
 import gg.essential.elementa.components.TreeNode
 import gg.essential.elementa.components.Window
+import gg.essential.elementa.components.image.ImageCache
 import gg.essential.elementa.constraints.HeightConstraint
 import gg.essential.elementa.dsl.pixels
 import gg.essential.elementa.events.UIEvent
@@ -34,6 +35,7 @@ class MarkdownComponent(
     private val codeFontPointSize: Float = 10f,
     private val codeFontRenderer: FontProvider = ElementaFonts.JETBRAINS_MONO,
     private val disableSelection: Boolean = false,
+    val imageCache: ImageCache? = null
 ) : UIComponent() {
 
     @JvmOverloads
@@ -42,7 +44,8 @@ class MarkdownComponent(
         config: MarkdownConfig = MarkdownConfig(),
         codeFontPointSize: Float = 10f,
         codeFontRenderer: FontProvider = ElementaFonts.JETBRAINS_MONO,
-    ) : this(text, config, codeFontPointSize, codeFontRenderer, false)
+        disableSelection: Boolean = false
+    ) : this(text, config, codeFontPointSize, codeFontRenderer, disableSelection, null)
 
     private val configState = BasicState(config)
     val config: MarkdownConfig

--- a/src/main/kotlin/gg/essential/elementa/markdown/MarkdownComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/MarkdownComponent.kt
@@ -35,8 +35,16 @@ class MarkdownComponent(
     private val codeFontPointSize: Float = 10f,
     private val codeFontRenderer: FontProvider = ElementaFonts.JETBRAINS_MONO,
     private val disableSelection: Boolean = false,
-    val imageCache: ImageCache? = null
+    val imageCache: ImageCache? = null,
 ) : UIComponent() {
+
+    constructor(
+        text: String,
+        config: MarkdownConfig = MarkdownConfig(),
+        codeFontPointSize: Float = 10f,
+        codeFontRenderer: FontProvider = ElementaFonts.JETBRAINS_MONO,
+        disableSelection: Boolean = false,
+    ) : this(text, config, codeFontPointSize, codeFontRenderer, disableSelection, null)
 
     @JvmOverloads
     constructor(
@@ -44,8 +52,7 @@ class MarkdownComponent(
         config: MarkdownConfig = MarkdownConfig(),
         codeFontPointSize: Float = 10f,
         codeFontRenderer: FontProvider = ElementaFonts.JETBRAINS_MONO,
-        disableSelection: Boolean = false
-    ) : this(text, config, codeFontPointSize, codeFontRenderer, disableSelection, null)
+    ) : this(text, config, codeFontPointSize, codeFontRenderer, false)
 
     private val configState = BasicState(config)
     val config: MarkdownConfig

--- a/src/main/kotlin/gg/essential/elementa/markdown/drawables/ImageDrawable.kt
+++ b/src/main/kotlin/gg/essential/elementa/markdown/drawables/ImageDrawable.kt
@@ -30,7 +30,8 @@ class ImageDrawable(md: MarkdownComponent, val url: URL, private val fallback: D
     private lateinit var imageX: ShiftableMDPixelConstraint
     private lateinit var imageY: ShiftableMDPixelConstraint
 
-    private val image = UIImage.ofURL(url) childOf md
+    private val image =
+        (if (md.imageCache == null) UIImage.ofURL(url) else UIImage.ofURL(url, md.imageCache)) childOf md
     private var hasLoaded = false
 
     override fun layoutImpl(x: Float, y: Float, width: Float): Layout {


### PR DESCRIPTION
This pull request allows the use of an `ImageCache` with `MarkdownComponent`, this change *should* be backwards compatible.