### PR TITLE
UIComponent: Improve vertical scrolling & add support for horizontal scrolling

### DIFF
--- a/api/Elementa.api
+++ b/api/Elementa.api
@@ -3,6 +3,7 @@ public final class gg/essential/elementa/ElementaVersion : java/lang/Enum {
 	public static final field V0 Lgg/essential/elementa/ElementaVersion;
 	public static final field V1 Lgg/essential/elementa/ElementaVersion;
 	public static final field V10 Lgg/essential/elementa/ElementaVersion;
+	public static final field V11 Lgg/essential/elementa/ElementaVersion;
 	public static final field V2 Lgg/essential/elementa/ElementaVersion;
 	public static final field V3 Lgg/essential/elementa/ElementaVersion;
 	public static final field V4 Lgg/essential/elementa/ElementaVersion;
@@ -118,6 +119,7 @@ public abstract class gg/essential/elementa/UIComponent : java/util/Observable, 
 	public fun mouseMove (Lgg/essential/elementa/components/Window;)V
 	public fun mouseRelease ()V
 	public fun mouseScroll (D)V
+	public fun mouseScroll (DD)V
 	public final fun onFocus (Lkotlin/jvm/functions/Function1;)Lgg/essential/elementa/UIComponent;
 	public final fun onFocusLost (Lkotlin/jvm/functions/Function1;)Lgg/essential/elementa/UIComponent;
 	public final fun onKeyType (Lkotlin/jvm/functions/Function3;)Lgg/essential/elementa/UIComponent;
@@ -272,7 +274,7 @@ public abstract class gg/essential/elementa/WindowScreen : gg/essential/universa
 	public fun onKeyPressed (ICLgg/essential/universal/UKeyboard$Modifiers;)V
 	public fun onMouseClicked (DDI)V
 	public fun onMouseReleased (DDI)V
-	public fun onMouseScrolled (D)V
+	public fun onMouseScrolled (DDDD)V
 	public fun onScreenClose ()V
 	public final fun stopAnimating (Lkotlin/reflect/KMutableProperty0;)V
 }
@@ -776,6 +778,7 @@ public final class gg/essential/elementa/components/Window : gg/essential/elemen
 	public fun mouseClick (DDI)V
 	public fun mouseRelease ()V
 	public fun mouseScroll (D)V
+	public fun mouseScroll (DD)V
 	public final fun removeFloatingComponent (Lgg/essential/elementa/UIComponent;)V
 	public final fun setHoveredFloatingComponent (Lgg/essential/elementa/UIComponent;)V
 	public final fun unfocus ()V
@@ -2748,14 +2751,20 @@ public abstract class gg/essential/elementa/events/UIEvent {
 
 public final class gg/essential/elementa/events/UIScrollEvent : gg/essential/elementa/events/UIEvent {
 	public fun <init> (DLgg/essential/elementa/UIComponent;Lgg/essential/elementa/UIComponent;)V
+	public fun <init> (DLgg/essential/elementa/UIComponent;Lgg/essential/elementa/UIComponent;D)V
 	public final fun component1 ()D
 	public final fun component2 ()Lgg/essential/elementa/UIComponent;
 	public final fun component3 ()Lgg/essential/elementa/UIComponent;
+	public final fun component4 ()D
 	public final fun copy (DLgg/essential/elementa/UIComponent;Lgg/essential/elementa/UIComponent;)Lgg/essential/elementa/events/UIScrollEvent;
+	public final fun copy (DLgg/essential/elementa/UIComponent;Lgg/essential/elementa/UIComponent;D)Lgg/essential/elementa/events/UIScrollEvent;
+	public static synthetic fun copy$default (Lgg/essential/elementa/events/UIScrollEvent;DLgg/essential/elementa/UIComponent;Lgg/essential/elementa/UIComponent;DILjava/lang/Object;)Lgg/essential/elementa/events/UIScrollEvent;
 	public static synthetic fun copy$default (Lgg/essential/elementa/events/UIScrollEvent;DLgg/essential/elementa/UIComponent;Lgg/essential/elementa/UIComponent;ILjava/lang/Object;)Lgg/essential/elementa/events/UIScrollEvent;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCurrentTarget ()Lgg/essential/elementa/UIComponent;
 	public final fun getDelta ()D
+	public final fun getDeltaHorizontal ()D
+	public final fun getDeltaVertical ()D
 	public final fun getTarget ()Lgg/essential/elementa/UIComponent;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/api/Elementa.api
+++ b/api/Elementa.api
@@ -274,6 +274,7 @@ public abstract class gg/essential/elementa/WindowScreen : gg/essential/universa
 	public fun onKeyPressed (ICLgg/essential/universal/UKeyboard$Modifiers;)V
 	public fun onMouseClicked (DDI)V
 	public fun onMouseReleased (DDI)V
+	public fun onMouseScrolled (D)V
 	public fun onMouseScrolled (DDDD)V
 	public fun onScreenClose ()V
 	public final fun stopAnimating (Lkotlin/reflect/KMutableProperty0;)V
@@ -2750,6 +2751,7 @@ public abstract class gg/essential/elementa/events/UIEvent {
 }
 
 public final class gg/essential/elementa/events/UIScrollEvent : gg/essential/elementa/events/UIEvent {
+	public fun <init> (DDLgg/essential/elementa/UIComponent;Lgg/essential/elementa/UIComponent;)V
 	public fun <init> (DLgg/essential/elementa/UIComponent;Lgg/essential/elementa/UIComponent;)V
 	public fun <init> (DLgg/essential/elementa/UIComponent;Lgg/essential/elementa/UIComponent;D)V
 	public final fun component1 ()D
@@ -2763,8 +2765,8 @@ public final class gg/essential/elementa/events/UIScrollEvent : gg/essential/ele
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCurrentTarget ()Lgg/essential/elementa/UIComponent;
 	public final fun getDelta ()D
-	public final fun getDeltaHorizontal ()D
-	public final fun getDeltaVertical ()D
+	public final fun getScrollX ()D
+	public final fun getScrollY ()D
 	public final fun getTarget ()Lgg/essential/elementa/UIComponent;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 kotlin = "1.9.25"
 kotlinx-coroutines = "1.5.2"
 jetbrains-annotations = "23.0.0"
-universalcraft = "431"
+universalcraft = "466"
 commonmark = "0.17.1"
 dom4j = "2.1.1"
 

--- a/src/main/kotlin/gg/essential/elementa/ElementaVersion.kt
+++ b/src/main/kotlin/gg/essential/elementa/ElementaVersion.kt
@@ -196,10 +196,11 @@ enum class ElementaVersion {
      * Improvements for vertical scrolling and support for horizontal scrolling.
      *
      * Adds new mouseScroll() function to UIComponent that also supports horizontal scrolling.
-     * The old function is no longer called by WindowScreen.
-     * Vertical deltas passed to the new function are now passed along unchanged.
-     * Previous they were coerced between -1.0 and 1.0 in WindowScreen.
+     * The old function is no longer supported and will no longer be called.
+     * Previously, deltas were always coerced between -1.0 and 1.0 in WindowScreen.
+     * This was wrong, and is no longer the case for the new function.
      * UIScrollEvent now includes also the horizontal delta.
+     * ScrollComponent now also properly supports new horizontal scrolling.
      *
      * See [UniversalCraft#128](https://github.com/SparkUniverse/UniversalCraft/pull/128) for the underlying changes.
      */

--- a/src/main/kotlin/gg/essential/elementa/ElementaVersion.kt
+++ b/src/main/kotlin/gg/essential/elementa/ElementaVersion.kt
@@ -189,7 +189,21 @@ enum class ElementaVersion {
      * This fixes the alpha channel of the render result, allowing it to be correctly composited with other textures.
      * See [UniversalCraft#105](https://github.com/EssentialGG/UniversalCraft/pull/105) for more details.
      */
+    @Deprecated(DEPRECATION_MESSAGE)
     V10,
+
+    /**
+     * Improvements for vertical scrolling and support for horizontal scrolling.
+     *
+     * Adds new mouseScroll() function to UIComponent that also supports horizontal scrolling.
+     * The old function is no longer called by WindowScreen.
+     * Vertical deltas passed to the new function are now passed along unchanged.
+     * Previous they were coerced between -1.0 and 1.0 in WindowScreen.
+     * UIScrollEvent now includes also the horizontal delta.
+     *
+     * See [UniversalCraft#128](https://github.com/SparkUniverse/UniversalCraft/pull/128) for the underlying changes.
+     */
+    V11,
 
     ;
 
@@ -241,12 +255,16 @@ Be sure to read through all the changes between your current version and your ne
         internal val v8 = V8
         @Suppress("DEPRECATION")
         internal val v9 = V9
+        @Suppress("DEPRECATION")
         internal val v10 = V10
+        internal val v11 = V11
 
         internal val atLeastV9Active: Boolean
             get() = active >= v9
         internal val atLeastV10Active: Boolean
             get() = active >= v10
+        internal val atLeastV11Active: Boolean
+            get() = active >= v11
 
         @PublishedApi
         internal var active: ElementaVersion = v0

--- a/src/main/kotlin/gg/essential/elementa/UIComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/UIComponent.kt
@@ -730,11 +730,8 @@ abstract class UIComponent : Observable(), ReferenceHolder {
         this.forEachChild { it.mouseRelease() }
     }
 
-    /**
-     * Runs the set [onMouseScroll] method for the component and it's children.
-     * Use this in the proper mouse scroll event to cascade all component's mouse scroll events.
-     * Most common use is on the [Window] object.
-     */
+    @Suppress("DEPRECATION")
+    @Deprecated("Not called by WindowScreen in elementa v11 and above", ReplaceWith("mouseScroll(deltaHorizontal, deltaVertical)"))
     open fun mouseScroll(delta: Double) {
         if (delta == 0.0) return
 
@@ -747,6 +744,25 @@ abstract class UIComponent : Observable(), ReferenceHolder {
         }
 
         fireScrollEvent(UIScrollEvent(delta, this, this))
+    }
+
+    /**
+     * Runs the set [onMouseScroll] method for the component and it's children.
+     * Use this in the proper mouse scroll event to cascade all component's mouse scroll events.
+     * Most common use is on the [Window] object.
+     */
+    open fun mouseScroll(deltaHorizontal: Double, deltaVertical: Double) {
+        if (deltaHorizontal == 0.0 && deltaVertical == 0.0) return
+
+        for (i in children.lastIndex downTo 0) {
+            val child = children[i]
+
+            if (child.isHovered()) {
+                return child.mouseScroll(deltaHorizontal, deltaVertical)
+            }
+        }
+
+        fireScrollEvent(UIScrollEvent(deltaVertical, this, this, deltaHorizontal))
     }
 
     open fun onWindowResize() {

--- a/src/main/kotlin/gg/essential/elementa/UIComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/UIComponent.kt
@@ -751,18 +751,18 @@ abstract class UIComponent : Observable(), ReferenceHolder {
      * Use this in the proper mouse scroll event to cascade all component's mouse scroll events.
      * Most common use is on the [Window] object.
      */
-    open fun mouseScroll(deltaHorizontal: Double, deltaVertical: Double) {
-        if (deltaHorizontal == 0.0 && deltaVertical == 0.0) return
+    open fun mouseScroll(scrollX: Double, scrollY: Double) {
+        if (scrollX == 0.0 && scrollY == 0.0) return
 
         for (i in children.lastIndex downTo 0) {
             val child = children[i]
 
             if (child.isHovered()) {
-                return child.mouseScroll(deltaHorizontal, deltaVertical)
+                return child.mouseScroll(scrollX, scrollY)
             }
         }
 
-        fireScrollEvent(UIScrollEvent(deltaVertical, this, this, deltaHorizontal))
+        fireScrollEvent(UIScrollEvent(scrollX, scrollY, this, this))
     }
 
     open fun onWindowResize() {

--- a/src/main/kotlin/gg/essential/elementa/WindowScreen.kt
+++ b/src/main/kotlin/gg/essential/elementa/WindowScreen.kt
@@ -86,14 +86,25 @@ abstract class WindowScreen @JvmOverloads constructor(
         window.mouseRelease()
     }
 
+    @Suppress("DEPRECATION")
+    @Deprecated(
+        "Provided `delta` values have different units depending on Minecraft versions. See ElementaVersion.V11 for details.",
+        replaceWith = ReplaceWith("onMouseScrolled(mouseX, mouseY, deltaHorizontal, deltaVertical)")
+    )
+    override fun onMouseScrolled(delta: Double) {
+        super.onMouseScrolled(delta)
+
+        if (version < ElementaVersion.v11) {
+            // We also need to pass along scrolling
+            window.mouseScroll(delta.coerceIn(-1.0, 1.0))
+        }
+    }
+
     override fun onMouseScrolled(mouseX: Double, mouseY: Double, deltaHorizontal: Double, deltaVertical: Double) {
         super.onMouseScrolled(mouseX, mouseY, deltaHorizontal, deltaVertical)
 
         if (version >= ElementaVersion.v11) {
             window.mouseScroll(deltaHorizontal, deltaVertical)
-        } else {
-            @Suppress("DEPRECATION")
-            window.mouseScroll(deltaVertical.coerceIn(-1.0, 1.0))
         }
     }
 

--- a/src/main/kotlin/gg/essential/elementa/WindowScreen.kt
+++ b/src/main/kotlin/gg/essential/elementa/WindowScreen.kt
@@ -86,11 +86,15 @@ abstract class WindowScreen @JvmOverloads constructor(
         window.mouseRelease()
     }
 
-    override fun onMouseScrolled(delta: Double) {
-        super.onMouseScrolled(delta)
+    override fun onMouseScrolled(mouseX: Double, mouseY: Double, deltaHorizontal: Double, deltaVertical: Double) {
+        super.onMouseScrolled(mouseX, mouseY, deltaHorizontal, deltaVertical)
 
-        // We also need to pass along scrolling
-        window.mouseScroll(delta.coerceIn(-1.0, 1.0))
+        if (version >= ElementaVersion.v11) {
+            window.mouseScroll(deltaHorizontal, deltaVertical)
+        } else {
+            @Suppress("DEPRECATION")
+            window.mouseScroll(deltaVertical.coerceIn(-1.0, 1.0))
+        }
     }
 
     override fun onKeyPressed(keyCode: Int, typedChar: Char, modifiers: UKeyboard.Modifiers?) {

--- a/src/main/kotlin/gg/essential/elementa/components/ScrollComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/ScrollComponent.kt
@@ -2,7 +2,6 @@ package gg.essential.elementa.components
 
 import gg.essential.elementa.ElementaVersion
 import gg.essential.elementa.UIComponent
-import gg.essential.elementa.components.UpdateFunc
 import gg.essential.elementa.constraints.*
 import gg.essential.elementa.constraints.animation.Animations
 import gg.essential.elementa.constraints.resolution.ConstraintVisitor
@@ -143,7 +142,29 @@ class ScrollComponent constructor(
 
 
     private val mouseScrollLambda: UIComponent.(UIScrollEvent) -> Unit = {
-        if (Window.of(this).version >= ElementaVersion.v5) {
+        if (Window.of(this).version >= ElementaVersion.v11) {
+            // For easier understanding we reframe the provided scroll in terms of primary and secondary directions
+            // We used to only get vertical scrolls, so that remains as the primary direction
+            val scrollPrimary = it.scrollY.toFloat()
+            val scrollSecondary = it.scrollX.toFloat()
+
+            // We map the primary and secondary scroll values based on the scroll direction
+            // `Vertical` and `Horizontal` directions disable the other direction, so we use 0f
+            val (providedX, providedY) = when (scrollDirection) {
+                Direction.Vertical -> 0f to scrollPrimary
+                Direction.Horizontal -> scrollPrimary to 0f
+                Direction.PreferVertical -> scrollSecondary to scrollPrimary
+                Direction.PreferHorizontal -> scrollPrimary to scrollSecondary
+            }
+
+            // We swap directions if shift is pressed
+            val (actualX, actualY) = if (UKeyboard.isShiftKeyDown()) providedY to providedX else providedX to providedY
+
+            // Finally, process the scroll with computed values
+            if (onScroll(actualX, actualY) || !passthroughScroll) {
+                it.stopPropagation()
+            }
+        } else if (Window.of(this).version >= ElementaVersion.v5) {
             // new behavior
             val scrollDirection = if (!UKeyboard.isShiftKeyDown()) primaryScrollDirection else secondaryScrollDirection
             if (scrollDirection != null) {
@@ -207,8 +228,7 @@ class ScrollComponent constructor(
 
         if (needsUpdate) {
             needsUpdate = false
-            val horizontalRange = calculateOffsetRange(isHorizontal = true)
-            val verticalRange = calculateOffsetRange(isHorizontal = false)
+            val (horizontalRange, verticalRange) = calculateOffsetRanges()
 
             // Recalculate our scroll box and move the content inside if needed.
             actualHolder.animate {
@@ -317,8 +337,7 @@ class ScrollComponent constructor(
         verticalOffset: Float = this.verticalOffset,
         smoothScroll: Boolean = true
     ) {
-        val horizontalRange = calculateOffsetRange(isHorizontal = true)
-        val verticalRange = calculateOffsetRange(isHorizontal = false)
+        val (horizontalRange, verticalRange) = calculateOffsetRanges()
         this.horizontalOffset =
             if (horizontalRange.isEmpty()) innerPadding else horizontalOffset.coerceIn(horizontalRange)
         this.verticalOffset = if (verticalRange.isEmpty()) {
@@ -425,13 +444,26 @@ class ScrollComponent constructor(
      * @return whether the offset changed
      */
     private fun onScroll(delta: Float, isHorizontal: Boolean): Boolean {
+        return if (isHorizontal) onScroll(delta, 0f) else onScroll(0f, delta)
+    }
+
+    /**
+     * @return whether either offset changed
+     */
+    private fun onScroll(scrollX: Float, scrollY: Float): Boolean {
         var changed = false
-        val offset = if (isHorizontal) ::horizontalOffset else ::verticalOffset
-        val range = calculateOffsetRange(isHorizontal)
-        val newOffset = if(range.isEmpty()) innerPadding else (offset.get() + delta * pixelsPerScroll * currentScrollAcceleration).coerceIn(range)
-        if (newOffset != offset.get()) {
+        val offsetX = ::horizontalOffset
+        val offsetY = ::verticalOffset
+        val (rangeX, rangeY) = calculateOffsetRanges()
+        val newOffsetX = if (rangeX.isEmpty()) innerPadding else (offsetX.get() + scrollX * pixelsPerScroll * currentScrollAcceleration).coerceIn(rangeX)
+        if (newOffsetX != offsetX.get()) {
             changed = true
-            offset.set(newOffset)
+            offsetX.set(newOffsetX)
+        }
+        val newOffsetY = if (rangeY.isEmpty()) innerPadding else (offsetY.get() + scrollY * pixelsPerScroll * currentScrollAcceleration).coerceIn(rangeY)
+        if (newOffsetY != offsetY.get()) {
+            changed = true
+            offsetY.set(newOffsetY)
         }
 
         currentScrollAcceleration =
@@ -511,16 +543,16 @@ class ScrollComponent constructor(
         }
     }
 
-    private fun calculateOffsetRange(isHorizontal: Boolean): ClosedFloatingPointRange<Float> {
-        return if (isHorizontal) {
-            val actualWidth = calculateActualWidth()
-            val maxNegative = this.getWidth() - actualWidth - innerPadding
-            if (horizontalScrollOpposite) (-innerPadding)..-maxNegative else maxNegative..(innerPadding)
-        } else {
-            val actualHeight = calculateActualHeight()
-            val maxNegative = this.getHeight() - actualHeight - innerPadding
-            if (verticalScrollOpposite) (-innerPadding)..-maxNegative else maxNegative..(innerPadding)
-        }
+    private fun calculateOffsetRanges(): Pair<ClosedFloatingPointRange<Float>, ClosedFloatingPointRange<Float>> {
+        val actualWidth = calculateActualWidth()
+        val maxNegativeWidth = this.getWidth() - actualWidth - innerPadding
+        val rangeX = if (horizontalScrollOpposite) (-innerPadding)..-maxNegativeWidth else maxNegativeWidth..(innerPadding)
+
+        val actualHeight = calculateActualHeight()
+        val maxNegativeHeight = this.getHeight() - actualHeight - innerPadding
+        val rangeY = if (verticalScrollOpposite) (-innerPadding)..-maxNegativeHeight else maxNegativeHeight..(innerPadding)
+
+        return rangeX to rangeY
     }
 
     private fun onClick(mouseX: Float, mouseY: Float, mouseButton: Int) {

--- a/src/main/kotlin/gg/essential/elementa/components/ScrollComponent.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/ScrollComponent.kt
@@ -142,33 +142,16 @@ class ScrollComponent constructor(
 
 
     private val mouseScrollLambda: UIComponent.(UIScrollEvent) -> Unit = {
-        if (Window.of(this).version >= ElementaVersion.v11) {
-            // For easier understanding we reframe the provided scroll in terms of primary and secondary directions
-            // We used to only get vertical scrolls, so that remains as the primary direction
-            val scrollPrimary = it.scrollY.toFloat()
-            val scrollSecondary = it.scrollX.toFloat()
-
-            // We map the primary and secondary scroll values based on the scroll direction
-            // `Vertical` and `Horizontal` directions disable the other direction, so we use 0f
-            val (providedX, providedY) = when (scrollDirection) {
-                Direction.Vertical -> 0f to scrollPrimary
-                Direction.Horizontal -> scrollPrimary to 0f
-                Direction.PreferVertical -> scrollSecondary to scrollPrimary
-                Direction.PreferHorizontal -> scrollPrimary to scrollSecondary
-            }
-
-            // We swap directions if shift is pressed
-            val (actualX, actualY) = if (UKeyboard.isShiftKeyDown()) providedY to providedX else providedX to providedY
-
-            // Finally, process the scroll with computed values
-            if (onScroll(actualX, actualY) || !passthroughScroll) {
-                it.stopPropagation()
-            }
-        } else if (Window.of(this).version >= ElementaVersion.v5) {
+        if (Window.of(this).version >= ElementaVersion.v5) {
             // new behavior
             val scrollDirection = if (!UKeyboard.isShiftKeyDown()) primaryScrollDirection else secondaryScrollDirection
             if (scrollDirection != null) {
                 if (onScroll(it.delta.toFloat(), isHorizontal = scrollDirection == Direction.Horizontal) || !passthroughScroll) {
+                    it.stopPropagation()
+                }
+            }
+            if(horizontalScrollEnabled) {
+                if (onScroll(it.scrollX.toFloat(), isHorizontal = true) || !passthroughScroll) {
                     it.stopPropagation()
                 }
             }
@@ -228,7 +211,8 @@ class ScrollComponent constructor(
 
         if (needsUpdate) {
             needsUpdate = false
-            val (horizontalRange, verticalRange) = calculateOffsetRanges()
+            val horizontalRange = calculateOffsetRange(isHorizontal = true)
+            val verticalRange = calculateOffsetRange(isHorizontal = false)
 
             // Recalculate our scroll box and move the content inside if needed.
             actualHolder.animate {
@@ -337,7 +321,8 @@ class ScrollComponent constructor(
         verticalOffset: Float = this.verticalOffset,
         smoothScroll: Boolean = true
     ) {
-        val (horizontalRange, verticalRange) = calculateOffsetRanges()
+        val horizontalRange = calculateOffsetRange(isHorizontal = true)
+        val verticalRange = calculateOffsetRange(isHorizontal = false)
         this.horizontalOffset =
             if (horizontalRange.isEmpty()) innerPadding else horizontalOffset.coerceIn(horizontalRange)
         this.verticalOffset = if (verticalRange.isEmpty()) {
@@ -444,26 +429,14 @@ class ScrollComponent constructor(
      * @return whether the offset changed
      */
     private fun onScroll(delta: Float, isHorizontal: Boolean): Boolean {
-        return if (isHorizontal) onScroll(delta, 0f) else onScroll(0f, delta)
-    }
-
-    /**
-     * @return whether either offset changed
-     */
-    private fun onScroll(scrollX: Float, scrollY: Float): Boolean {
+        if (delta == 0f) return false
         var changed = false
-        val offsetX = ::horizontalOffset
-        val offsetY = ::verticalOffset
-        val (rangeX, rangeY) = calculateOffsetRanges()
-        val newOffsetX = if (rangeX.isEmpty()) innerPadding else (offsetX.get() + scrollX * pixelsPerScroll * currentScrollAcceleration).coerceIn(rangeX)
-        if (newOffsetX != offsetX.get()) {
+        val offset = if (isHorizontal) ::horizontalOffset else ::verticalOffset
+        val range = calculateOffsetRange(isHorizontal)
+        val newOffset = if(range.isEmpty()) innerPadding else (offset.get() + delta * pixelsPerScroll * currentScrollAcceleration).coerceIn(range)
+        if (newOffset != offset.get()) {
             changed = true
-            offsetX.set(newOffsetX)
-        }
-        val newOffsetY = if (rangeY.isEmpty()) innerPadding else (offsetY.get() + scrollY * pixelsPerScroll * currentScrollAcceleration).coerceIn(rangeY)
-        if (newOffsetY != offsetY.get()) {
-            changed = true
-            offsetY.set(newOffsetY)
+            offset.set(newOffset)
         }
 
         currentScrollAcceleration =
@@ -543,16 +516,16 @@ class ScrollComponent constructor(
         }
     }
 
-    private fun calculateOffsetRanges(): Pair<ClosedFloatingPointRange<Float>, ClosedFloatingPointRange<Float>> {
-        val actualWidth = calculateActualWidth()
-        val maxNegativeWidth = this.getWidth() - actualWidth - innerPadding
-        val rangeX = if (horizontalScrollOpposite) (-innerPadding)..-maxNegativeWidth else maxNegativeWidth..(innerPadding)
-
-        val actualHeight = calculateActualHeight()
-        val maxNegativeHeight = this.getHeight() - actualHeight - innerPadding
-        val rangeY = if (verticalScrollOpposite) (-innerPadding)..-maxNegativeHeight else maxNegativeHeight..(innerPadding)
-
-        return rangeX to rangeY
+    private fun calculateOffsetRange(isHorizontal: Boolean): ClosedFloatingPointRange<Float> {
+        return if (isHorizontal) {
+            val actualWidth = calculateActualWidth()
+            val maxNegative = this.getWidth() - actualWidth - innerPadding
+            if (horizontalScrollOpposite) (-innerPadding)..-maxNegative else maxNegative..(innerPadding)
+        } else {
+            val actualHeight = calculateActualHeight()
+            val maxNegative = this.getHeight() - actualHeight - innerPadding
+            if (verticalScrollOpposite) (-innerPadding)..-maxNegative else maxNegative..(innerPadding)
+        }
     }
 
     private fun onClick(mouseX: Float, mouseY: Float, mouseButton: Int) {

--- a/src/main/kotlin/gg/essential/elementa/components/Window.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/Window.kt
@@ -244,7 +244,7 @@ class Window @JvmOverloads constructor(
         super.mouseScroll(delta)
     }
 
-    override fun mouseScroll(deltaHorizontal: Double, deltaVertical: Double) {
+    override fun mouseScroll(scrollX: Double, scrollY: Double) {
         if (hasErrored && version >= ElementaVersion.v7) {
             return
         }
@@ -254,12 +254,12 @@ class Window @JvmOverloads constructor(
         val (mouseX, mouseY) = getMousePosition()
         for (floatingComponent in allFloatingComponentsInReverseOrder()) {
             if (floatingComponent.isPointInside(mouseX, mouseY)) {
-                floatingComponent.mouseScroll(deltaHorizontal, deltaVertical)
+                floatingComponent.mouseScroll(scrollX, scrollY)
                 return
             }
         }
 
-        super.mouseScroll(deltaHorizontal, deltaVertical)
+        super.mouseScroll(scrollX, scrollY)
     }
 
     override fun mouseClick(mouseX: Double, mouseY: Double, button: Int) {

--- a/src/main/kotlin/gg/essential/elementa/components/Window.kt
+++ b/src/main/kotlin/gg/essential/elementa/components/Window.kt
@@ -224,6 +224,8 @@ class Window @JvmOverloads constructor(
         }
     }
 
+    @Suppress("DEPRECATION")
+    @Deprecated("Not called in elementa v11 and above", ReplaceWith("mouseScroll(0.0, delta)"))
     override fun mouseScroll(delta: Double) {
         if (hasErrored && version >= ElementaVersion.v7) {
             return
@@ -240,6 +242,24 @@ class Window @JvmOverloads constructor(
         }
 
         super.mouseScroll(delta)
+    }
+
+    override fun mouseScroll(deltaHorizontal: Double, deltaVertical: Double) {
+        if (hasErrored && version >= ElementaVersion.v7) {
+            return
+        }
+
+        requireMainThread()
+
+        val (mouseX, mouseY) = getMousePosition()
+        for (floatingComponent in allFloatingComponentsInReverseOrder()) {
+            if (floatingComponent.isPointInside(mouseX, mouseY)) {
+                floatingComponent.mouseScroll(deltaHorizontal, deltaVertical)
+                return
+            }
+        }
+
+        super.mouseScroll(deltaHorizontal, deltaVertical)
     }
 
     override fun mouseClick(mouseX: Double, mouseY: Double, button: Int) {

--- a/src/main/kotlin/gg/essential/elementa/events/UIMouseEvents.kt
+++ b/src/main/kotlin/gg/essential/elementa/events/UIMouseEvents.kt
@@ -15,22 +15,25 @@ data class UIClickEvent(
 }
 
 data class UIScrollEvent(
-    val deltaVertical: Double,
+    val scrollY: Double,
     val target: UIComponent,
     val currentTarget: UIComponent,
-    val deltaHorizontal: Double,
+    val scrollX: Double, // only on Minecraft 1.20.2+ and ElementaVersion.V11+
 ) : UIEvent() {
+    constructor(scrollX: Double, scrollY: Double, target: UIComponent, currentTarget: UIComponent)
+            : this(scrollY, target, currentTarget, scrollX)
+
     // Added to ensure backwards binary compatibility
     constructor(delta: Double, target: UIComponent, currentTarget: UIComponent) : this(delta, target, currentTarget, 0.0)
 
     // Added to ensure backwards binary compatibility
     fun copy(
-        deltaVertical: Double = this.deltaVertical,
+        delta: Double = this.scrollY,
         target: UIComponent = this.target,
         currentTarget: UIComponent = this.currentTarget,
-    ) = copy(deltaVertical = deltaVertical, target = target, currentTarget = currentTarget, deltaHorizontal = deltaHorizontal)
+    ) = copy(scrollY = delta, target = target, currentTarget = currentTarget, scrollX = scrollX)
 
     // Added to ensure backwards binary compatibility
     val delta: Double
-        get() = deltaVertical
+        get() = scrollY
 }

--- a/src/main/kotlin/gg/essential/elementa/events/UIMouseEvents.kt
+++ b/src/main/kotlin/gg/essential/elementa/events/UIMouseEvents.kt
@@ -15,7 +15,22 @@ data class UIClickEvent(
 }
 
 data class UIScrollEvent(
-    val delta: Double,
+    val deltaVertical: Double,
     val target: UIComponent,
-    val currentTarget: UIComponent
-) : UIEvent()
+    val currentTarget: UIComponent,
+    val deltaHorizontal: Double,
+) : UIEvent() {
+    // Added to ensure backwards binary compatibility
+    constructor(delta: Double, target: UIComponent, currentTarget: UIComponent) : this(delta, target, currentTarget, 0.0)
+
+    // Added to ensure backwards binary compatibility
+    fun copy(
+        deltaVertical: Double = this.deltaVertical,
+        target: UIComponent = this.target,
+        currentTarget: UIComponent = this.currentTarget,
+    ) = copy(deltaVertical = deltaVertical, target = target, currentTarget = currentTarget, deltaHorizontal = deltaHorizontal)
+
+    // Added to ensure backwards binary compatibility
+    val delta: Double
+        get() = deltaVertical
+}


### PR DESCRIPTION
This PR implements the new mouse scroll callback introduced in [UniversalCraft#128](https://github.com/SparkUniverse/UniversalCraft/pull/128) under a new Elementa version. Now that scroll deltas are consistent across versions, we stop coercing them to the -1.0 to 1.0 range to allow much more natural scrolling. Alongside this we also add horizontal scrolling
support.

Linear: EM-3575