### PR TITLE
Build: Set `FMLModType: GAMELIBRARY` in manifest

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,6 +72,7 @@ tasks.processResources {
 tasks.jar {
     dependsOn(internal)
     from({ internal.map { zipTree(it) } })
+    manifest.attributes(mapOf("FMLModType" to "GAMELIBRARY"))
 }
 
 apiValidation {


### PR DESCRIPTION
This is necessary for (Neo)Forge to put Elementa in the correct ClassLoader (namely one with access to UniversalCraft and therefore indirectly Minecraft).

This should enable use of Elementa in Forge development environments and even via jar-in-jar on 26.1+ NeoForge.

Note: The attribute value required for this was changed from `LIBRARY` to `GAMELIBRARY` with ModLauncher 9 (Minecraft 1.17), so this won't work in a Forge for Minecraft 1.16 development environment. (see also https://github.com/SparkUniverse/UniversalCraft/pull/104) Having it work on all versions would require we ship different jars for different versions, which I'd like to avoid.
This should not affect usage of Elementa in 1.16 Forge production environments, since jar-in-jar wasn't properly supported yet in 1.16, so you have to bundle and relocated Elementa into your main mod jar anyway, and as such it will be loaded on the correct ClassLoader (the same one as your mod).