### PR TITLE
Example: Fix cat url thumbnail size

### DIFF
--- a/example/src/main/kotlin/gg/essential/elementa/example/ComponentsGui.kt
+++ b/example/src/main/kotlin/gg/essential/elementa/example/ComponentsGui.kt
@@ -344,7 +344,7 @@ class ComponentsGui : WindowScreen(ElementaVersion.V2) {
     companion object {
         // AdinaVoicu, CC0, via Wikimedia Commons
         // https://commons.wikimedia.org/wiki/File:Tabby_cat_with_blue_eyes-3336579.jpg
-        val exampleImageUrl = URL("https://upload.wikimedia.org/wikipedia/commons/thumb/c/c7/Tabby_cat_with_blue_eyes-3336579.jpg/200px-Tabby_cat_with_blue_eyes-3336579.jpg")
+        val exampleImageUrl = URL("https://upload.wikimedia.org/wikipedia/commons/thumb/c/c7/Tabby_cat_with_blue_eyes-3336579.jpg/250px-Tabby_cat_with_blue_eyes-3336579.jpg")
         val exampleBlurHash = "K8HnZ@.7|,4TIr?H01My5Y"
     }
 }


### PR DESCRIPTION
Wikimedia at some point started requiring that thumbnails use only a specific set of sizes, and 200 wasn't in that set.

See https://w.wiki/GHai